### PR TITLE
PHP syntax colors

### DIFF
--- a/colors/getafe.vim
+++ b/colors/getafe.vim
@@ -187,3 +187,10 @@ hi Exception       guifg=#FF0000
 hi Include         guifg=#FF0000
 
 
+" PHP specific colors
+hi phpStructure    guifg=#69C3FF                                       ctermfg=154
+hi phpRegion       guifg=#AEEE00                                       ctermfg=204
+hi phpStorageClass guifg=#69C3FF
+hi phpRepeat       guifg=#FF6E0E
+hi phpIdentifier   guifg=#F8FFF9
+hi phpMethodsVar   guifg=#69C3FF


### PR DESCRIPTION
theres no highlight for some php groups, i added this groups and now looks like this 
![Captura de pantalla de 2013-02-11 13:51:16](https://f.cloud.github.com/assets/1450169/146790/454bfb12-7495-11e2-961e-81e5ede6f788.png)
